### PR TITLE
Fix default_epsilon for Df64

### DIFF
--- a/src/checks.rs
+++ b/src/checks.rs
@@ -86,10 +86,11 @@ impl approx::AbsDiffEq for Df64 {
 
     #[inline(always)]
     fn default_epsilon() -> Self::Epsilon {
-        // A useful default absolute tolerance is one at the floor of the
-        // double range, since otherwise it is not clear what the scale is.
-        // We also ignore denormal numbers.
-        return Df64::MIN_POSITIVE;
+        // Use a reasonable multiple of the machine epsilon for Df64.
+        // Df64::EPSILON ≈ 2.47e-32 represents the effective precision.
+        // Using MIN_POSITIVE (≈ 1e-292) causes excessive iterations in
+        // iterative algorithms like SVD, leading to numerical error accumulation.
+        return Df64::EPSILON;
     }
 
     #[inline(always)]


### PR DESCRIPTION
## Summary

Fixes default_epsilon implementation for Df64 to use Df64::EPSILON instead of Df64::MIN_POSITIVE.

## Problem
Using MIN_POSITIVE (~1e-292) as default epsilon caused excessive iterations in numerical algorithms like SVD, leading to numerical error accumulation and paradoxically worse precision.

## Solution
Changed to Df64::EPSILON (~2.47e-32) which represents the actual precision of double-double arithmetic and provides appropriate convergence criteria.

## Changes
- src/checks.rs: Updated default_epsilon to return Df64::EPSILON

## Testing
All existing tests pass.