### PR TITLE
Remove wildcard imports from source files

### DIFF
--- a/src/circular.rs
+++ b/src/circular.rs
@@ -1,11 +1,14 @@
 use std::f64;
 
-use super::utils::reciprocal_factorial;
 use super::Df64;
-use super::arith::*;
+use super::arith::{
+    addfast_dq, addfast_qd, addfast_qq, mul_dd, mul_pow2, reciprocal_q, sqrt_q, square_q,
+    subfast_dq, subfast_qq,
+};
+use super::checks::{is_finite, is_nan, is_zero};
 use super::consts;
-use super::checks::*;
-use super::funcs::*;
+use super::funcs::{abs, copysign};
+use super::utils::reciprocal_factorial;
 
 pub fn sin(x: Df64) -> Df64
 {

--- a/src/exp.rs
+++ b/src/exp.rs
@@ -1,6 +1,10 @@
-use super::*;
-use super::arith::*;
-use super::checks::*;
+use super::Df64;
+use super::arith::{
+    addfast_dq, addfast_qd, addfast_qq, mul_pow2, square_q, subfast_qd, subfast_qq,
+};
+use super::checks::is_nan;
+use super::consts;
+use super::funcs;
 use super::utils::reciprocal_factorial;
 use libm::ldexp;
 
@@ -412,6 +416,7 @@ const fn expm1_alphas(n: i32) -> Df64
 #[cfg(test)]
 mod test {
     use super::*;
+    use super::super::checks::{is_finite, is_infinite, is_zero};
     use super::super::test_utils::*;
 
     #[test]

--- a/src/gauss.rs
+++ b/src/gauss.rs
@@ -6,8 +6,8 @@
 // Copyright (C) 2023-2025 Markus Wallerberger and others
 // SPDX-License-Identifier: MIT
 use super::Df64;
-use super::arith::*;
-use super::circular::*;
+use super::arith::square_q;
+use super::circular::{cos, sincos};
 use super::consts;
 
 pub fn gauss_legendre(x: &mut [Df64], w: &mut [Df64])

--- a/src/hyperbolic.rs
+++ b/src/hyperbolic.rs
@@ -1,9 +1,12 @@
 use super::Df64;
-use super::arith::*;
-use super::checks::*;
-use super::funcs::*;
-use super::roots::*;
-use super::exp::*;
+use super::arith::{
+    addfast_dq, addfast_qq, mul_pow2, reciprocal_q, sqrt_q, square_q, subfast_dq, subfast_qd,
+    subfast_qq,
+};
+use super::checks::{is_finite, is_nan};
+use super::exp::{exp_split, expm1, log, log1p};
+use super::funcs::{abs, copysign, ldexp};
+use super::roots::{hypot, inv_sqrt};
 
 pub const COSH_MAX: f64 = 710.4758600739439;
 
@@ -169,6 +172,7 @@ pub fn atanh(x: Df64) -> Df64
 mod test{
     use super::*;
     use super::super::test_utils::*;
+    use super::super::checks::is_infinite;
 
     #[test]
     fn test_cosh()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,6 @@
 
 use core::f64;
 use std::ops::{Add, Sub};
-use num_traits::Zero;
 
 /// Type for compensated arithmetic.
 #[derive(PartialEq, PartialOrd, Clone, Copy, Debug)]

--- a/src/roots.rs
+++ b/src/roots.rs
@@ -1,5 +1,5 @@
 use super::Df64;
-use super::arith::*;
+use super::arith::{addfast_dd, addfast_qq, mul_pow2, reciprocal_d, sqrt_q, square_q};
 
 pub fn hypot(x: Df64, y: Df64) -> Df64
 {
@@ -75,6 +75,7 @@ pub fn inv_sqrt(x: Df64) -> Df64
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::arith::{div_qd, mul_qd};
     use crate::checks::*;
     use crate::test_utils::*;
 

--- a/src/round.rs
+++ b/src/round.rs
@@ -4,7 +4,9 @@
  * SPDX-License-Identifier: MIT
  */
 use super::Df64;
-use super::arith::*;
+use super::arith::{
+    add_qd, addfast_dd, div_dq, div_qd, div_qq, mul_dq, mul_qq, subfast_dq, subfast_qq,
+};
 
 pub fn ceil(x: Df64) -> Df64
 {

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -3,11 +3,15 @@
  * Copyright (C) 2023-2025 Markus Wallerberger and others
  * SPDX-License-Identifier: MIT
  */
-use super::*;
-use std::ops::*;
-use num_traits::*;
+use super::Df64;
+use super::{AddFast, CompensatedArithmetic, SubFast};
+use super::{arith, checks, circular, consts, exp, funcs, hyperbolic, roots, round};
+use num_traits::{Inv, Num, One, Signed, Zero};
+use simba::scalar::{ComplexField, Field, RealField, SubsetOf, SupersetOf};
 use simba::simd::SimdValue;
-use simba::scalar::*;
+use std::ops::{
+    Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Rem, RemAssign, Sub, SubAssign,
+};
 
 // ---------------------------------------------------------------------------
 // STANDARD TRAITS


### PR DESCRIPTION
## Problem

The codebase uses wildcard imports (`use module::*`) extensively in production code, which makes it difficult to understand where symbols come from and can lead to name collisions. This was reported in #11.

The Rust language design team recommends using explicit imports for better code readability and maintainability, reserving wildcard imports only for preludes and test modules.

## Solution

- Replaced all wildcard imports in production code with explicit imports
- Affected files:
  - `src/roots.rs` - explicit imports from `arith` module
  - `src/round.rs` - explicit imports from `arith` module
  - `src/gauss.rs` - explicit imports from `arith` and `circular` modules
  - `src/circular.rs` - explicit imports from `arith`, `checks`, `funcs`, and `utils` modules
  - `src/exp.rs` - explicit imports from multiple modules
  - `src/hyperbolic.rs` - explicit imports from `arith`, `checks`, `exp`, `funcs`, and `roots` modules
  - `src/traits.rs` - explicit imports from `std::ops`, `num_traits`, and `simba::scalar`
  - `src/lib.rs` - removed unused `num_traits::Zero` import
- Test module wildcard imports (`use super::*;`) are intentionally kept as they are considered acceptable in Rust best practices

## Testing

- All 36 tests pass successfully
- No functional changes to the code
- Only import statements were modified

## Impact

This change improves code readability by making it clear where each imported symbol comes from, making the codebase easier to understand and maintain.

Resolves #11
