### PR TITLE
Implement num_traits::FloatConst for Df64

### DIFF
--- a/src/consts.rs
+++ b/src/consts.rs
@@ -164,8 +164,9 @@ mod test
         assert_ulps_eq!(exp::exp(Df64::ONE), EULER_E);
         assert_ulps_eq!(RADIANS_PER_DEGREE, arith::div_qd(PI, 180.0));
         assert_ulps_eq!(DEGREES_PER_RADIAN, arith::mul_qd(ONE_OVER_PI, 180.0));
-        assert_ulps_eq!(SQRT_2 * SQRT_2, Df64::from(2.0));
-        assert_ulps_eq!(FRAC_1_SQRT_2 * SQRT_2, Df64::ONE);
-        assert_ulps_eq!(LOG10_2 * LOG2_10, Df64::ONE);
+        assert_ulps_eq!(SQRT_2, arith::sqrt_q(Df64::from(2.0)));
+        assert_ulps_eq!(FRAC_1_SQRT_2, roots::inv_sqrt(Df64::from(2.0)));
+        assert_ulps_eq!(LOG10_2, LOG10_E * LN_2);
+        assert_ulps_eq!(LOG2_10, LOG2_E * LN_10);
     }
 }

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -119,6 +119,18 @@ pub const LN_2: Df64 = Df64 {hi: 0.6931471805599453, lo: 2.3190468138462996e-17}
 /// Natural logarithm of 10
 pub const LN_10: Df64 = Df64 {hi: 2.302585092994046, lo: -2.1707562233822494e-16};
 
+/// Logarithm base-10 of 2
+pub const LOG10_2: Df64 = Df64 {hi: 0.30102999566398120, lo: -2.8037281277851704e-18};
+
+/// Logarithm base-2 of 10
+pub const LOG2_10: Df64 = Df64 {hi: 3.321928094887362, lo: 1.661617516973592e-16};
+
+/// Square root of 2
+pub const SQRT_2: Df64 = Df64 {hi: 1.4142135623730951, lo: -9.667293313452913e-17};
+
+/// Reciprocal of square root of 2 (1/√2 = √2/2)
+pub const FRAC_1_SQRT_2: Df64 = Df64 {hi: 0.7071067811865476, lo: -4.833646656726457e-17};
+
 /// Radians per degree (π/180)
 pub const RADIANS_PER_DEGREE: Df64 = Df64 {hi: 0.017453292519943295, lo: 2.9486522708701687e-19};
 
@@ -152,5 +164,8 @@ mod test
         assert_ulps_eq!(exp::exp(Df64::ONE), EULER_E);
         assert_ulps_eq!(RADIANS_PER_DEGREE, arith::div_qd(PI, 180.0));
         assert_ulps_eq!(DEGREES_PER_RADIAN, arith::mul_qd(ONE_OVER_PI, 180.0));
+        assert_ulps_eq!(SQRT_2 * SQRT_2, Df64::from(2.0));
+        assert_ulps_eq!(FRAC_1_SQRT_2 * SQRT_2, Df64::ONE);
+        assert_ulps_eq!(LOG10_2 * LOG2_10, Df64::ONE);
     }
 }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -2110,6 +2110,31 @@ mod test
         assert_ulps_eq!(Float::to_radians(Df64::from(-180.0)), -crate::consts::PI);
     }
 
+    #[test]
+    fn test_float_const()
+    {
+        use num_traits::FloatConst;
+        assert_eq!(Df64::E(), consts::EULER_E);
+        assert_eq!(Df64::FRAC_1_PI(), consts::ONE_OVER_PI);
+        assert_eq!(Df64::FRAC_1_SQRT_2(), consts::FRAC_1_SQRT_2);
+        assert_eq!(Df64::FRAC_2_PI(), consts::TWO_OVER_PI);
+        assert_eq!(Df64::FRAC_2_SQRT_PI(), consts::TWO_OVER_SQRT_PI);
+        assert_eq!(Df64::FRAC_PI_2(), consts::PI_HALF);
+        assert_eq!(Df64::FRAC_PI_3(), consts::PI_THIRD);
+        assert_eq!(Df64::FRAC_PI_4(), consts::PI_FOURTH);
+        assert_eq!(Df64::FRAC_PI_6(), consts::PI_SIXTH);
+        assert_eq!(Df64::FRAC_PI_8(), consts::PI_EIGHTH);
+        assert_eq!(Df64::LN_10(), consts::LN_10);
+        assert_eq!(Df64::LN_2(), consts::LN_2);
+        assert_eq!(Df64::LOG10_E(), consts::LOG10_E);
+        assert_eq!(Df64::LOG2_E(), consts::LOG2_E);
+        assert_eq!(Df64::PI(), consts::PI);
+        assert_eq!(Df64::SQRT_2(), consts::SQRT_2);
+        assert_eq!(Df64::TAU(), consts::TWO_PI);
+        assert_eq!(Df64::LOG10_2(), consts::LOG10_2);
+        assert_eq!(Df64::LOG2_10(), consts::LOG2_10);
+    }
+
     // ===== Float trait not yet implemented (2 methods) =====
 
     #[test]

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -302,6 +302,106 @@ impl Signed for Df64 {
     }
 }
 
+/// Implementation of the `num_traits::FloatConst` trait for `Df64`.
+///
+/// This provides standard mathematical constants in double-double precision.
+impl num_traits::FloatConst for Df64 {
+    #[inline(always)]
+    fn E() -> Self {
+        consts::EULER_E
+    }
+
+    #[inline(always)]
+    fn FRAC_1_PI() -> Self {
+        consts::ONE_OVER_PI
+    }
+
+    #[inline(always)]
+    fn FRAC_1_SQRT_2() -> Self {
+        consts::FRAC_1_SQRT_2
+    }
+
+    #[inline(always)]
+    fn FRAC_2_PI() -> Self {
+        consts::TWO_OVER_PI
+    }
+
+    #[inline(always)]
+    fn FRAC_2_SQRT_PI() -> Self {
+        consts::TWO_OVER_SQRT_PI
+    }
+
+    #[inline(always)]
+    fn FRAC_PI_2() -> Self {
+        consts::PI_HALF
+    }
+
+    #[inline(always)]
+    fn FRAC_PI_3() -> Self {
+        consts::PI_THIRD
+    }
+
+    #[inline(always)]
+    fn FRAC_PI_4() -> Self {
+        consts::PI_FOURTH
+    }
+
+    #[inline(always)]
+    fn FRAC_PI_6() -> Self {
+        consts::PI_SIXTH
+    }
+
+    #[inline(always)]
+    fn FRAC_PI_8() -> Self {
+        consts::PI_EIGHTH
+    }
+
+    #[inline(always)]
+    fn LN_10() -> Self {
+        consts::LN_10
+    }
+
+    #[inline(always)]
+    fn LN_2() -> Self {
+        consts::LN_2
+    }
+
+    #[inline(always)]
+    fn LOG10_E() -> Self {
+        consts::LOG10_E
+    }
+
+    #[inline(always)]
+    fn LOG2_E() -> Self {
+        consts::LOG2_E
+    }
+
+    #[inline(always)]
+    fn PI() -> Self {
+        consts::PI
+    }
+
+    #[inline(always)]
+    fn SQRT_2() -> Self {
+        consts::SQRT_2
+    }
+
+    #[inline(always)]
+    fn TAU() -> Self {
+        consts::TWO_PI
+    }
+
+    #[inline(always)]
+    fn LOG10_2() -> Self {
+        consts::LOG10_2
+    }
+
+    #[inline(always)]
+    fn LOG2_10() -> Self {
+        consts::LOG2_10
+    }
+}
+
 /// Implementation of the `num_traits::Float` trait for `Df64`.
 ///
 /// This provides standard floating-point operations without depending on


### PR DESCRIPTION
Closes #18

## Summary

This PR implements the `num_traits::FloatConst` trait for `Df64`, providing standard mathematical constants in double-double precision.

## Changes

### New constants in `consts.rs`
- `SQRT_2` - Square root of 2
- `FRAC_1_SQRT_2` - Reciprocal of square root of 2 (1/√2)
- `LOG10_2` - Logarithm base-10 of 2
- `LOG2_10` - Logarithm base-2 of 10

### `FloatConst` implementation in `traits.rs`
- All 16 required methods: `E`, `PI`, `FRAC_1_PI`, `FRAC_2_PI`, `FRAC_PI_2`, `FRAC_PI_3`, `FRAC_PI_4`, `FRAC_PI_6`, `FRAC_PI_8`, `FRAC_1_SQRT_2`, `FRAC_2_SQRT_PI`, `LN_2`, `LN_10`, `LOG2_E`, `LOG10_E`, `SQRT_2`
- All 3 provided methods with optimized implementations: `TAU`, `LOG10_2`, `LOG2_10`

### Tests
- Added accuracy tests for new constants in `consts.rs`
